### PR TITLE
refactor: :recycle: simplify the condition to add the separator

### DIFF
--- a/lib/separated_column.dart
+++ b/lib/separated_column.dart
@@ -37,7 +37,7 @@ class SeparatedColumn extends StatelessWidget {
       for (int i = 0; i < this.children.length; i++) {
         children.add(this.children[i]);
 
-        if (this.children.length - i != 1) {
+        if (i < this.children.length - 1) {
           children.add(separatorBuilder(context, i + index));
         }
       }


### PR DESCRIPTION
Hello 👋🏻

In this PR, I have rewritten the condition of deciding whether to add the separator between children or not to be more readable and understandable...

```Diff
- if (this.children.length - i != 1) {
+ if (i < this.children.length - 1) {
     children.add(separatorBuilder(context, i));
  }
```

Your condition was asking if the **remaining** items ( `this.children.length - i` ) is not equal to `1`, which means item is not the last item. What I have done is to literally translate that into code, so I have transformed the question from **Are the remaining items count not equal to one?** to **Is the item is not the last one?**, so it became simpler and intuitive, also the expression ( `this.children.length - 1` ) is a very common expression in programming to get the index of the last item in a list, which makes it easier to understand.

I hope you like that 🙏🏻

Thanks 💙
